### PR TITLE
Remove null chars from ldap attributes string 

### DIFF
--- a/modules/core/src/com/haulmont/addon/ldap/core/dao/UserSynchronizationLogDao.java
+++ b/modules/core/src/com/haulmont/addon/ldap/core/dao/UserSynchronizationLogDao.java
@@ -222,6 +222,6 @@ public class UserSynchronizationLogDao {
             }
             sb.append("\n");
         }
-        return sb.toString();
+        return sb.toString().replaceAll("\0", "");
     }
 }


### PR DESCRIPTION
to prevent "invalid byte sequence for encoding utf8 0x00" in Postgres