### PR TITLE
ldap-addon-49 Restrict substitution of inactive users

### DIFF
--- a/modules/core/src/com/haulmont/addon/ldap/core/aop/UserSubstitutionChecker.java
+++ b/modules/core/src/com/haulmont/addon/ldap/core/aop/UserSubstitutionChecker.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.addon.ldap.core.aop;
+
+import com.haulmont.addon.ldap.core.dao.LdapUserDao;
+import com.haulmont.addon.ldap.dto.LdapUser;
+import com.haulmont.cuba.core.global.UserSessionSource;
+import com.haulmont.cuba.core.sys.ConditionalOnAppProperty;
+import com.haulmont.cuba.security.entity.User;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Aspect
+@Component
+@ConditionalOnAppProperty(property = "ldap.userSubstitutionCheckerEnabled", value = "true")
+public class UserSubstitutionChecker {
+
+	private static final Logger log = LoggerFactory.getLogger(UserSubstitutionChecker.class);
+
+	@Inject
+	private LdapUserDao ldapUserDao;
+
+	@Inject
+	protected UserSessionSource userSessionSource;
+
+	@Pointcut("execution(* com.haulmont.cuba.security.auth.AuthenticationServiceBean.substituteUser(..))")
+	public void substituteUserPointcut() { }
+
+	@Around("substituteUserPointcut()")
+	public Object beforeUserSubstitution(ProceedingJoinPoint pjp) throws Throwable {
+		Optional<User> userArg = getUserArg(pjp.getArgs());
+
+		if (userArg.isPresent()) {
+			User cubaUser = userArg.get();
+			String userLogin = cubaUser.getLogin();
+			LdapUser ldapUser = ldapUserDao.getLdapUser(userLogin);
+
+			if (ldapUser != null && ldapUser.getDisabled()) {
+				log.warn(String.format("Unable to switch to user '%s': the user is disabled", userLogin));
+				return userSessionSource.getUserSession();
+			}
+		}
+
+		return pjp.proceed();
+	}
+
+	private static Optional<User> getUserArg(Object[] args) {
+		return Arrays.stream(args)
+				.filter(arg -> arg instanceof User)
+				.map(user -> (User) user)
+				.findFirst();
+	}
+}

--- a/modules/core/src/com/haulmont/addon/ldap/spring.xml
+++ b/modules/core/src/com/haulmont/addon/ldap/spring.xml
@@ -19,9 +19,10 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:ldap="http://www.springframework.org/schema/ldap"
+       xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd
-        http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+        http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
     <!-- Annotation-based beans -->
     <context:component-scan base-package="com.haulmont.addon.ldap"/>
@@ -36,4 +37,5 @@
 
     <ldap:ldap-template id="ldap_ldapTemplate" context-source-ref="ldap_ldapContextSource"/>
 
+    <aop:aspectj-autoproxy/>
 </beans>


### PR DESCRIPTION
Added 'silent' user switch rejection it user is disabled. This solution just make unnable to switch on disabled LDAP user. The only issue is taht this doesn't make any GUI notifications that user can't be switched. This check works only if `app.properties` file has `ldap.userSubstitutionCheckerEnabled = true`. 